### PR TITLE
 Adds ServiceCaller module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    the_help (1.0.2)
+    the_help (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/the_help/provides_callbacks.rb
+++ b/lib/the_help/provides_callbacks.rb
@@ -54,6 +54,7 @@ module TheHelp
       # @param name [Symbol] The name of the callback
       # @param block [Proc] The code that will be executed in the context of the
       #   object when the callback is invoked.
+      # @return [self]
       def callback(name, &block)
         define_method("#{name}_without_logging", &block)
         define_method(name) do |*args|
@@ -61,6 +62,7 @@ module TheHelp
             logger.debug("#{inspect} received callback :#{name}.")
           end
           send("#{name}_without_logging", *args)
+          self
         end
         private name
         self

--- a/lib/the_help/service.rb
+++ b/lib/the_help/service.rb
@@ -62,6 +62,7 @@ module TheHelp
   # CreateNewUserAccount.(context: current_user, user: new_user_object)
   class Service
     include ProvidesCallbacks
+    include ServiceCaller
 
     # The default :not_authorized callback
     #

--- a/lib/the_help/service.rb
+++ b/lib/the_help/service.rb
@@ -73,6 +73,16 @@ module TheHelp
     }
 
     class << self
+      # Defines attr_accessors with scoping options
+      def attr_accessor(*names, make_private: false, private_reader: false,
+                        private_writer: false)
+        super(*names)
+        names.each do |name|
+          private name if make_private || private_reader
+          private "#{name}=" if make_private || private_writer
+        end
+      end
+
       # Convenience method to instantiate the service and immediately call it
       #
       # Any arguments are passed to #initialize
@@ -124,7 +134,7 @@ module TheHelp
       end
 
       def input(name, **options)
-        attr_accessor name
+        attr_accessor name, make_private: true
         if options.key?(:default)
           required_inputs.delete(name)
           define_method(name) do
@@ -133,7 +143,6 @@ module TheHelp
         else
           required_inputs << name
         end
-        private name, "#{name}="
         self
       end
     end

--- a/lib/the_help/service_caller.rb
+++ b/lib/the_help/service_caller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module TheHelp
+  # Provides convenience method for calling services
+  #
+  # The including module/class MUST provide the #service_context and
+  # #service_logger methods, which will be provided as the called-service's
+  # `context` and `logger` arguments, respectively.
+  #
+  # @example
+  #   class Foo
+  #     include TheHelp::ServiceCaller
+  #
+  #     def do_something
+  #       call_service(MyService, some: 'arguments')
+  #     end
+  #
+  #     private
+  #
+  #     def service_context
+  #       # something that provides the context
+  #     end
+  #
+  #     def service_logger
+  #       # an instance of a `Logger`
+  #     end
+  #   end
+  module ServiceCaller
+    # Calls the specified service
+    #
+    # @param service [Class<TheHelp::Service>]
+    # @param args [Hash<Symbol, Object>] Any additional keyword arguments are
+    #        passed directly to the service.
+    # @return [self]
+    def call_service(service, **args)
+      service_args = {
+        context: service_context,
+        logger: service_logger
+      }.merge(args)
+      service.call(**service_args)
+      self
+    end
+  end
+end

--- a/lib/the_help/version.rb
+++ b/lib/the_help/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TheHelp
-  VERSION = '1.0.2'
+  VERSION = '1.1.0'
 end

--- a/spec/the_help/provides_callbacks_spec.rb
+++ b/spec/the_help/provides_callbacks_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TheHelp::ProvidesCallbacks do
           collaborator.do_something(done: callback(:my_callback))
         end
 
-        callback :my_callback do |something: |
+        callback :my_callback do |something:|
           collaborator.callback_received(something)
         end
       end
@@ -27,7 +27,7 @@ RSpec.describe TheHelp::ProvidesCallbacks do
 
     let(:collaborator) {
       double('collaborator', callback_received: nil).tap do |c|
-        allow(c).to receive(:do_something) { |done: |
+        allow(c).to receive(:do_something) { |done:|
           done.call(something: 123)
         }
       end

--- a/spec/the_help/service_caller_spec.rb
+++ b/spec/the_help/service_caller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'the_help/service_caller'
+
+RSpec.describe TheHelp::ServiceCaller do
+  let(:includer) {
+    Class.new do
+      include TheHelp::ServiceCaller
+
+      attr_accessor :service, :service_context, :service_logger, :arg1, :arg2
+
+      def initialize(**args)
+        args.each do |(k, v)|
+          send("#{k}=", v)
+        end
+      end
+
+      def do_something
+        call_service(service,
+                     arg1: arg1,
+                     arg2: arg2)
+      end
+    end
+  }
+
+  subject {
+    includer.new(
+      service: service,
+      service_context: service_context,
+      service_logger: service_logger,
+      arg1: arg1,
+      arg2: arg2
+    )
+  }
+
+  let(:service) { instance_double('Proc', call: nil) }
+  let(:service_context) { double('context') }
+  let(:service_logger) { double('logger') }
+  let(:arg1) { double('arg1') }
+  let(:arg2) { double('arg2') }
+
+  it "calls the specified service using the including module's " \
+     'service_context and service_logger' do
+    subject.do_something
+    expect(service).to have_received(:call).with(
+      context: service_context,
+      logger: service_logger,
+      arg1: arg1,
+      arg2: arg2
+    )
+  end
+end


### PR DESCRIPTION
Every service requires the caller to pass in the context and the logger.
This can create a lot of noise in an application that uses service calls
frequently. This simply adds a bit of syntactic sugar to keep the code
more focused on the details that are relevant to the business purpose of
the code instead of the mechanics of the framework.